### PR TITLE
Add support to ZSTD compression when using LTO Mode

### DIFF
--- a/gcc.spec
+++ b/gcc.spec
@@ -68,6 +68,7 @@ BuildRequires : glibc-libc32
 BuildRequires : glibc-dev32
 BuildRequires : docbook-xml docbook-utils doxygen
 BuildRequires : util-linux
+BuildRequires : zstd-dev
 
 
 Requires: gcc-libubsan = %{version}-%{release}


### PR DESCRIPTION
Hello,

I would like to suggest adding zstd-dev as a Build Requirement to support ZSTD compression on GCC, which should considerably speed up when compiling in LTO mode.